### PR TITLE
Fix package_linter error

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -133,7 +133,7 @@ fi
 #=================================================
 
 exec_artisan "app:update"
-rm -rf bootstrap/cache/*
+ynh_secure_remove --file=bootstrap/cache/*
 
 #=================================================
 # GENERIC FINALIZATION


### PR DESCRIPTION
✘ [YEP-2.12] You should avoid using 'rm -rf', please use 'ynh_secure_remove' instead 