### PR TITLE
Bump version to 2.3.18 + small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a [Cachet](https://cachethq.io/) package for YunoHost.
 
 ---
 
-**Shipped version:** 2.3.15
+**Shipped version:** 2.3.18
 
 [Cachet](https://cachethq.io/) is a free, open source status page for your API, service or company. Built with all of the features that you'd expect from a status page, Cachet comes with a powerful API, a metric system, multiple user support, two factor authentication for added security and is easy to get setup. A powerful, self-hosted alternative to StatusPage.io and Status.io.
 

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/CachetHQ/Cachet/archive/v2.3.15.tar.gz
-SOURCE_SUM=8e7ebbdbbc101403c47a286de796b648149ab362d71f16bdf7dba8f0416fd720
+SOURCE_URL=https://github.com/CachetHQ/Cachet/archive/v2.3.18.tar.gz
+SOURCE_SUM=ba74a1f83a0d4f800d02584de285bfabe28b4c5e2408b23af30a2dee9d65174d
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -36,7 +36,7 @@ init_composer() {
 
   # update dependencies to create composer.lock
   exec_composer "$destdir" install --no-dev \
-    || ynh_die "Unable to update Roundcube core dependencies"
+    || ynh_die "Unable to update Cachet core dependencies"
 }
 
 # Execute a command with occ

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 # =============================================================================
 
 # Package dependencies
-pkg_dependencies="php5-gd php5-mcrypt"
+pkg_dependencies="php5-gd php5-mcrypt php-mbstring"
 
 # =============================================================================
 # COMMON CACHET FUNCTIONS


### PR DESCRIPTION
Bump to the latest release.

Just got this working on a testing hetzner box.

Btw, the current 2.3.15 fails without the `php-mbstring` also.