### PR TITLE
[buster] Update dependencies for buster (get rid of php-mcrypt)

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 # =============================================================================
 
 # Package dependencies
-pkg_dependencies="php5-gd php5-mcrypt php-mbstring"
+pkg_dependencies="php-gd php-mbstring"
 
 # =============================================================================
 # COMMON CACHET FUNCTIONS


### PR DESCRIPTION
Like for roundcube and nextcloud, php-mcrypt ain't available anymore and is probably not needed by the app anymore (as suggested by [this commit?](https://github.com/CachetHQ/Cachet/commit/44481c46480d4f6b5ce26920e95df065b7a33338))

I didn't test the app install with this change though ...